### PR TITLE
TemX Initialize size correction

### DIFF
--- a/nonRigidICP.h
+++ b/nonRigidICP.h
@@ -489,7 +489,7 @@ public:
 			
 			
 			//temporal X
-			Eigen::MatrixX3d TmpX(3,4*n);
+			Eigen::MatrixX3d TmpX(4*n,3);
 			TmpX=X;
 			
 


### PR DESCRIPTION
After switching CMAKE_BUILD_TYPE to DEBUG, TemX Matrix initialization will fail